### PR TITLE
Fixes bug where arrays copied into js_state were four times too small.

### DIFF
--- a/procgen/src/games/maze.cpp
+++ b/procgen/src/games/maze.cpp
@@ -169,22 +169,21 @@ class MazeGame : public BasicAbstractGame {
 
         auto latent_state = get_latent_state();
 
-        auto* js_state = static_cast<client::MazeState*>(this->state);
+        auto *js_state = static_cast<client::MazeState *>(this->state);
 
         js_state->set_grid_width(latent_state.grid_width);
         js_state->set_grid_height(latent_state.grid_height);
 
-        int32_t grid_size = latent_state.grid_width*latent_state.grid_height;
-        int32_t* grid = new int32_t[grid_size];
+        int32_t grid_size = latent_state.grid_width * latent_state.grid_height;
+        int32_t *grid = new int32_t[grid_size];
         auto grid_start = latent_state.grid.begin();
         auto grid_stop = latent_state.grid.begin();
         std::advance(grid_stop, grid_size);
         std::copy(grid_start, grid_stop, grid);
-        js_state->set_grid(cheerp::MakeTypedArray(grid, grid_size));
+        js_state->set_grid(cheerp::MakeTypedArray(grid, grid_size * 4));
 
         js_state->set_agent_x(latent_state.agent_x);
         js_state->set_agent_y(latent_state.agent_y);
-
     }
 };
 

--- a/procgen/src/games/miner.cpp
+++ b/procgen/src/games/miner.cpp
@@ -357,18 +357,18 @@ class MinerGame : public BasicAbstractGame {
 
         auto latent_state = get_latent_state();
 
-        auto* js_state = static_cast<client::MinerState*>(this->state);
+        auto *js_state = static_cast<client::MinerState *>(this->state);
 
         js_state->set_grid_width(latent_state.grid_width);
         js_state->set_grid_height(latent_state.grid_height);
 
-        int32_t grid_size = latent_state.grid_width*latent_state.grid_height;
-        int32_t* grid = new int32_t[grid_size];
+        int32_t grid_size = latent_state.grid_width * latent_state.grid_height;
+        int32_t *grid = new int32_t[grid_size];
         auto grid_start = latent_state.grid.begin();
         auto grid_stop = latent_state.grid.begin();
         std::advance(grid_stop, grid_size);
         std::copy(grid_start, grid_stop, grid);
-        js_state->set_grid(cheerp::MakeTypedArray(grid, grid_size));
+        js_state->set_grid(cheerp::MakeTypedArray(grid, grid_size * 4));
 
         js_state->set_agent_x(latent_state.agent_x);
         js_state->set_agent_y(latent_state.agent_y);


### PR DESCRIPTION
I'm not sure why, but cheerp::MakeTypedArray creates an array four times to small with the current code. I suspect there is some disconnect between block sizes somewhere (16 to 64 bit integers or something like that), but I never tracked it down exactly. This change fixes the issue, and I've confirmed it was exactly a multiple-of-four issue by manually setting grid_size to a couple different values.